### PR TITLE
Allow Everbook to handle sub-iotas in non-lists

### DIFF
--- a/Common/src/main/java/ram/talia/hexal/api/casting/iota/IMappableIota.java
+++ b/Common/src/main/java/ram/talia/hexal/api/casting/iota/IMappableIota.java
@@ -1,0 +1,17 @@
+package ram.talia.hexal.api.casting.iota;
+
+import at.petrak.hexcasting.api.casting.iota.Iota;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * An Interface to facilitate replacing illegal Iotas.
+ */
+public interface IMappableIota {
+    /**
+     * Returns a new iota consisting of the result of applying the given function to the contents of this iota.
+     * <br />
+     * Implementations should apply <code>mapper</code> to every sub-iota ({@link Iota#subIotas()}), then return a copy of itself containing the mapped iotas.
+     */
+    Iota mapSubIotas(UnaryOperator<Iota> mapper);
+}

--- a/Common/src/main/java/ram/talia/hexal/api/casting/mishaps/MishapIllegalInterworldIota.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/casting/mishaps/MishapIllegalInterworldIota.kt
@@ -11,6 +11,7 @@ import at.petrak.hexcasting.api.utils.isOfTag
 import at.petrak.hexcasting.common.lib.hex.HexIotaTypes
 import net.minecraft.network.chat.Component
 import net.minecraft.world.item.DyeColor
+import ram.talia.hexal.api.casting.iota.IMappableIota
 import ram.talia.hexal.common.lib.HexalTags
 
 class MishapIllegalInterworldIota(val iota: Iota) : Mishap() {
@@ -36,8 +37,8 @@ class MishapIllegalInterworldIota(val iota: Iota) : Mishap() {
                 val iotaToCheck = poolToSearch.removeFirst()
                 if (iotaTypeIsIllegal(iotaToCheck))
                     return iotaToCheck
-                if (iotaToCheck is ListIota)
-                    poolToSearch.addAll(iotaToCheck.list)
+                if (iotaToCheck.subIotas() != null)
+                    poolToSearch.addAll(iotaToCheck.subIotas()!!)
             }
 
             return null
@@ -46,6 +47,7 @@ class MishapIllegalInterworldIota(val iota: Iota) : Mishap() {
         fun replaceInNestedIota(iota: Iota): Iota {
             return when {
                 iotaTypeIsIllegal(iota) -> GarbageIota()
+                iota is IMappableIota -> iota.mapSubIotas(::replaceInNestedIota)
                 iota is ListIota -> iota.list.map { replaceInNestedIota(it) }.asActionResult[0]
                 else -> iota
             }


### PR DESCRIPTION
Changes `getNestedIota` to check for subiotas rather than just for list iotas
Adds an interface to allow addons to handle iota replacement